### PR TITLE
Update newrelic.js

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -13,7 +13,7 @@ exports.config = {
   /**
    * Your New Relic license key.
    */
-  license_key: 'process.env.NEW_RELIC_LICENSE_KEY',
+  license_key: process.env.NEW_RELIC_LICENSE_KEY,
   /**
    * This setting controls distributed tracing.
    * Distributed tracing lets you see the path that a request takes through your


### PR DESCRIPTION
Since you are referencing an env variable, it's not a string, so you don't want to wrap it in quotes